### PR TITLE
Handle missing system tray

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,8 +123,12 @@ def main():
     server.newConnection.connect(lambda: window.show_window())
 
     hot_mgr = HotkeyManager(cfg_mgr, window)
-    tray = create_tray(app, window.show_window, hot_mgr.cfg.hotkey.upper(), 
-                       lambda: on_custom_wrapper(hot_mgr, tray, cfg_mgr))
+    tray = create_tray(
+        app,
+        window.show_window,
+        hot_mgr.cfg.hotkey.upper(),
+        lambda: on_custom_wrapper(hot_mgr, tray, cfg_mgr),
+    )
     app.aboutToQuit.connect(cfg_mgr.save)
 
     window.show_window()
@@ -134,7 +138,7 @@ def main():
 
 def on_custom_wrapper(hot_mgr, tray, cfg_mgr):
     new_seq = hot_mgr.on_custom()
-    if new_seq:
+    if new_seq and tray:
         tray.hotkey_action.setText(f"热键: {new_seq.upper()}")
 
 if __name__ == "__main__":

--- a/tray.py
+++ b/tray.py
@@ -7,12 +7,21 @@ from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtCore import Qt
 
 def create_tray(app, show_cb, hotkey="Ctrl+Alt+P", custom_cb=None):
+    """Create and return the system tray icon.
+
+    If the current platform does not support a system tray, ``None`` is
+    returned so callers can handle the absence of a tray icon gracefully.
+    """
     # 兼容打包后临时目录
-    icon_file = os.path.join(getattr(sys, "_MEIPASS", os.path.dirname(__file__)), "icon.png")
-    tray = QSystemTrayIcon(QIcon(icon_file), app)
+    icon_file = os.path.join(
+        getattr(sys, "_MEIPASS", os.path.dirname(__file__)), "icon.png"
+    )
+
     if not QSystemTrayIcon.isSystemTrayAvailable():
         print("System tray not available")
-        return tray
+        return None
+
+    tray = QSystemTrayIcon(QIcon(icon_file), app)
 
     menu = QMenu()
 


### PR DESCRIPTION
## Summary
- return `None` from `create_tray()` when the system tray isn't available
- guard system tray references in `main.py`

## Testing
- `python -m py_compile tray.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68407b79aeb88322815e0b2b696d92a4