### PR TITLE
Introduce model and controller for prompt data

### DIFF
--- a/promptlauncher/__init__.py
+++ b/promptlauncher/__init__.py
@@ -2,6 +2,8 @@ from .gui import PromptWindow
 from .tray import create_tray
 from .hotkey import get_custom_hotkey
 from .ssh_backup import SshBackupManager
+from .model import PromptModel
+from .controller import PromptController
 from .main import main
 
 __all__ = [
@@ -9,5 +11,7 @@ __all__ = [
     "create_tray",
     "get_custom_hotkey",
     "SshBackupManager",
+    "PromptModel",
+    "PromptController",
     "main",
 ]

--- a/promptlauncher/controller.py
+++ b/promptlauncher/controller.py
@@ -1,0 +1,35 @@
+from .model import PromptModel
+
+class PromptController:
+    """High level operations for PromptWindow."""
+    def __init__(self, model: PromptModel):
+        self.model = model
+
+    def save(self):
+        self.model.save()
+
+    # group operations
+    def add_group(self, name: str):
+        self.model.add_group(name)
+
+    def delete_group(self, name: str):
+        self.model.delete_group(name)
+
+    def rename_group(self, old: str, new: str):
+        self.model.rename_group(old, new)
+
+    # prompt operations
+    def add_prompt(self, group: str, alias: str, text: str):
+        self.model.add_prompt(group, alias, text)
+
+    def update_prompt(self, group: str, old_alias: str, new_alias: str, text: str):
+        self.model.update_prompt(group, old_alias, new_alias, text)
+
+    def delete_prompt(self, group: str, alias: str):
+        self.model.delete_prompt(group, alias)
+
+    def increment_usage(self, group: str, alias: str):
+        self.model.increment_usage(group, alias)
+
+    def get_prompt_text(self, group: str, alias: str) -> str:
+        return self.model.prompt_dict.get(group, {}).get(alias, "")

--- a/promptlauncher/model.py
+++ b/promptlauncher/model.py
@@ -1,0 +1,80 @@
+import os
+import json
+
+class PromptModel:
+    """Model for loading and saving prompt data."""
+    def __init__(self, path: str):
+        self.path = path
+        self.prompt_dict: dict[str, dict[str, str]] = {}
+        self.usage_counts: dict[str, dict[str, int]] = {}
+        self.load()
+
+    def load(self):
+        if not os.path.exists(self.path):
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            with open(self.path, 'w', encoding='utf-8') as f:
+                json.dump({"default": {}}, f, ensure_ascii=False, indent=2)
+
+        with open(self.path, 'r', encoding='utf-8') as f:
+            data = json.load(f) or {}
+
+        self.prompt_dict = {}
+        self.usage_counts = {}
+        for grp, amap in data.items():
+            self.prompt_dict[grp] = {}
+            self.usage_counts[grp] = {}
+            for alias, val in amap.items():
+                self.prompt_dict[grp][alias] = val.get('text', '')
+                self.usage_counts[grp][alias] = val.get('count', 0)
+
+    def save(self):
+        out: dict[str, dict[str, dict[str, int | str]]] = {}
+        for grp, amap in self.prompt_dict.items():
+            out[grp] = {}
+            for alias, text in amap.items():
+                cnt = self.usage_counts.get(grp, {}).get(alias, 0)
+                out[grp][alias] = {'text': text, 'count': cnt}
+        with open(self.path, 'w', encoding='utf-8') as f:
+            json.dump(out, f, ensure_ascii=False, indent=2)
+
+    # ---------- prompt/group operations ----------
+    def add_group(self, name: str):
+        if name not in self.prompt_dict:
+            self.prompt_dict[name] = {}
+            self.usage_counts[name] = {}
+            self.save()
+
+    def delete_group(self, name: str):
+        if name in self.prompt_dict:
+            self.prompt_dict.pop(name, None)
+            self.usage_counts.pop(name, None)
+            self.save()
+
+    def rename_group(self, old: str, new: str):
+        if old in self.prompt_dict and new not in self.prompt_dict:
+            self.prompt_dict[new] = self.prompt_dict.pop(old)
+            self.usage_counts[new] = self.usage_counts.pop(old)
+            self.save()
+
+    def add_prompt(self, group: str, alias: str, text: str):
+        self.prompt_dict.setdefault(group, {})[alias] = text
+        self.usage_counts.setdefault(group, {}).setdefault(alias, 0)
+        self.save()
+
+    def update_prompt(self, group: str, old_alias: str, new_alias: str, text: str):
+        if new_alias != old_alias:
+            self.prompt_dict[group].pop(old_alias, None)
+            self.usage_counts[group].pop(old_alias, None)
+        self.prompt_dict.setdefault(group, {})[new_alias] = text
+        self.usage_counts.setdefault(group, {}).setdefault(new_alias, 0)
+        self.save()
+
+    def delete_prompt(self, group: str, alias: str):
+        self.prompt_dict.get(group, {}).pop(alias, None)
+        self.usage_counts.get(group, {}).pop(alias, None)
+        self.save()
+
+    def increment_usage(self, group: str, alias: str):
+        self.usage_counts.setdefault(group, {}).setdefault(alias, 0)
+        self.usage_counts[group][alias] += 1
+        self.save()


### PR DESCRIPTION
## Summary
- add `PromptModel` and `PromptController` modules
- expose the new classes in `promptlauncher.__init__`
- refactor `PromptWindow` to delegate data handling to the controller

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407f32949c83229ebfe5f71754ac39