### PR TITLE
Add unified logging configuration

### DIFF
--- a/promptlauncher/logging_config.py
+++ b/promptlauncher/logging_config.py
@@ -1,0 +1,21 @@
+import logging
+
+LOG_FORMAT = "[%(asctime)s] %(levelname)s:%(name)s: %(message)s"
+
+def setup_logging(level=logging.INFO):
+    """Configure application-wide logging.
+
+    If the root logger is already configured, this function does nothing.
+    Returns the root logger instance.
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return root
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    root.setLevel(level)
+    root.addHandler(handler)
+
+    # Reduce verbosity for third-party libraries
+    logging.getLogger("paramiko").setLevel(logging.WARNING)
+    return root

--- a/promptlauncher/main.py
+++ b/promptlauncher/main.py
@@ -1,5 +1,6 @@
 # main.py
 import os, sys, json, keyboard, ctypes
+import logging
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtGui import QIcon
 from PyQt6.QtCore import QTimer
@@ -8,6 +9,9 @@ from .gui import PromptWindow
 from .tray import create_tray
 from .hotkey import get_custom_hotkey
 from .ssh_backup import SshBackupManager
+from .logging_config import setup_logging
+
+logger = logging.getLogger(__name__)
 
 BASE = getattr(sys, "frozen", False) and os.path.dirname(sys.executable) or os.path.dirname(__file__)
 CONFIG_PATH = os.path.join(BASE, ".config")
@@ -104,6 +108,8 @@ class HotkeyManager:
         return new_seq
 
 def main():
+    setup_logging()
+    logger.info("PromptLauncher starting")
     app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
     app.setWindowIcon(QIcon(ICON_FILE))
@@ -134,6 +140,7 @@ def main():
     window.show_window()
     ret = app.exec()
     cfg_mgr.save()
+    logger.info("PromptLauncher exiting")
     sys.exit(ret)
 
 def on_custom_wrapper(hot_mgr, tray, cfg_mgr):

--- a/promptlauncher/ssh_backup.py
+++ b/promptlauncher/ssh_backup.py
@@ -1,21 +1,14 @@
 import os
 import paramiko
 import logging
+from .logging_config import setup_logging
 import posixpath
 import threading
 from PyQt6.QtCore import QTimer
 from datetime import datetime
 
-# 配置日志输出
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-formatter = logging.Formatter('[%(asctime)s] %(levelname)s:%(name)s: %(message)s')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-paramiko_logger = logging.getLogger('paramiko')
-paramiko_logger.setLevel(logging.DEBUG)
-paramiko_logger.addHandler(handler)
+setup_logging(logging.DEBUG)
 
 class SshBackupManager:
     """

--- a/promptlauncher/tray.py
+++ b/promptlauncher/tray.py
@@ -1,10 +1,15 @@
 import os, sys
+import logging
+from .logging_config import setup_logging
 from PyQt6.QtWidgets import (
     QSystemTrayIcon, QMenu, QApplication,
     QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel
 )
 from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtCore import Qt
+
+logger = logging.getLogger(__name__)
+setup_logging()
 
 def create_tray(app, show_cb, hotkey="Ctrl+Alt+P", custom_cb=None):
     """Create and return the system tray icon.
@@ -18,7 +23,7 @@ def create_tray(app, show_cb, hotkey="Ctrl+Alt+P", custom_cb=None):
     )
 
     if not QSystemTrayIcon.isSystemTrayAvailable():
-        print("System tray not available")
+        logger.warning("System tray not available")
         return None
 
     tray = QSystemTrayIcon(QIcon(icon_file), app)


### PR DESCRIPTION
## Summary
- provide global `setup_logging` helper
- log startup and shutdown in the main module
- switch modules to use shared logging setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684080d7dce88322a2295bc1a1f598a4